### PR TITLE
[SCR-48] Fix Layerbank borrow balance

### DIFF
--- a/adapters/layerbank/src/index.ts
+++ b/adapters/layerbank/src/index.ts
@@ -52,7 +52,7 @@ export const getUserTVLByBlock = async (blocks: BlockData) => {
   console.log(`Block: ${block}`);
   console.log("States: ", states.length);
 
-  await updateBorrowBalances(states);
+  await updateBorrowBalances(states, BigInt(block));
 
   states.forEach((state) => {
     const marketInfo = marketInfos.find(


### PR DESCRIPTION
The borrow balances were incorrect and consistently more than the actual value at a given block from the adapter.

The fix is to grab the borrow balances and update them based on the block (making a historical `eth_call`)